### PR TITLE
Add lightweight deform option

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -63,6 +63,7 @@ class ModelParams(ParamGroup):
         self.data_device = "cuda"
         self.eval = True
         self.lod = 0
+        self.lightweight_deform = False
         super().__init__(parser, "Loading Parameters", sentinel)
 
     def extract(self, args):

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -218,6 +218,29 @@ class Channel_CTX_fea_tiny(nn.Module):
             return mean_d4, scale_d4, prob_d4
         return mean_adj, scale_adj, prob_adj
 
+class Channel_CTX_fea_lightweight(nn.Module):
+    """Simplified context model with fewer parameters."""
+    def __init__(self, feat_dim=50, n_offsets=5):
+        super().__init__()
+        self.feat_dim = feat_dim
+        self.n_offsets = n_offsets
+        in_dim = feat_dim * 4  # fea_q + [mean, scale, prob]
+        hid_dim = feat_dim
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hid_dim),
+            nn.LeakyReLU(inplace=True),
+            nn.Linear(hid_dim, feat_dim * 3),
+        )
+
+    def forward(self, fea_q, mean_scale, to_dec=-1):
+        x = torch.cat([fea_q, mean_scale], dim=-1)
+        mean_adj, scale_adj, prob_adj = torch.chunk(self.net(x), 3, dim=-1)
+        if to_dec == -1:
+            return mean_adj, scale_adj, prob_adj
+        step = self.feat_dim // self.n_offsets
+        b, e = step * to_dec, step * (to_dec + 1)
+        return mean_adj[:, b:e], scale_adj[:, b:e], prob_adj[:, b:e]
+
 class GaussianModel(nn.Module):
 
     def setup_functions(self):
@@ -254,6 +277,7 @@ class GaussianModel(nn.Module):
                  use_2D: bool=True,
                  decoded_version: bool=False,
                  is_synthetic_nerf: bool=False,
+                 lightweight_deform: bool=False,
                  ):
         super().__init__()
         print('hash_params:', use_2D, n_features_per_level,
@@ -281,6 +305,7 @@ class GaussianModel(nn.Module):
         self.Q = Q
         self.use_2D = use_2D
         self.decoded_version = decoded_version
+        self.lightweight_deform = lightweight_deform
 
         self._anchor = torch.empty(0)
         self._offset = torch.empty(0)
@@ -372,7 +397,10 @@ class GaussianModel(nn.Module):
             nn.Linear(feat_dim*2, (feat_dim+6+3*self.n_offsets)*2+feat_dim+1+1+1),
         ).cuda()
 
-        if not is_synthetic_nerf:
+        if lightweight_deform:
+            print('using lightweight context model')
+            self.mlp_deform = Channel_CTX_fea_lightweight(feat_dim=feat_dim, n_offsets=n_offsets).cuda()
+        elif not is_synthetic_nerf:
             self.mlp_deform = Channel_CTX_fea().cuda()
         else:
             print('find synthetic nerf, use Channel_CTX_fea_tiny')

--- a/train.py
+++ b/train.py
@@ -94,6 +94,7 @@ def training(args_param, dataset, opt, pipe, dataset_name, testing_iterations, s
         log2_hashmap_size=args_param.log2,
         log2_hashmap_size_2D=args_param.log2_2D,
         is_synthetic_nerf=is_synthetic_nerf,
+        lightweight_deform=args_param.lightweight_deform,
     )
     scene = Scene(dataset, gaussians, ply_path=ply_path)
     gaussians.update_anchor_bound()
@@ -431,6 +432,7 @@ def render_sets(args_param, dataset : ModelParams, iteration : int, pipeline : P
             log2_hashmap_size_2D=args_param.log2_2D,
             decoded_version=run_codec,
             is_synthetic_nerf=is_synthetic_nerf,
+            lightweight_deform=args_param.lightweight_deform,
         )
         scene = Scene(dataset, gaussians, load_iteration=iteration, shuffle=False)
         gaussians.eval()


### PR DESCRIPTION
## Summary
- add lightweight context model class
- allow selecting lightweight deform network
- expose option via arguments and `train.py`

## Testing
- `python -m compileall scene/gaussian_model.py arguments/__init__.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ae2b3be4832e94ff982d39bfd9a0